### PR TITLE
[WeeklyReport] sanbuphy 2023.11.13~2023.11.26

### DIFF
--- a/Reports/sanbuphy/[WeeklyReport]2023.11.13~2023.11.26.md
+++ b/Reports/sanbuphy/[WeeklyReport]2023.11.13~2023.11.26.md
@@ -1,0 +1,25 @@
+### 姓名
+
+卢雨畋 (sanbuphy)
+
+### 开发中的快乐开源任务
+
+暂无
+
+### 本双周工作
+
+1. **fastdeploy版的sd15模型添加gradio界面**
+
+   - <https://github.com/PaddlePaddle/PaddleMIX/pull/311>
+
+2. **问题疑惑与解答**
+
+暂无
+
+### 未来双周计划
+
+1. 第一个pr还有一些问题，解决了：
+   - 需要一些常见的这种参数。
+   - 有个可以跑通推理的paddle和fd及ppdiffusers环境，可以继续这部分开发了
+   - inpaint的界面，可能需要自动涂抹mask的工具，无需手动上传
+2. 完成音乐任务的gradio界面


### PR DESCRIPTION
### 姓名

卢雨畋 (sanbuphy)

### 开发中的快乐开源任务

暂无

### 本双周工作

1. **fastdeploy版的sd15模型添加gradio界面**

   - <https://github.com/PaddlePaddle/PaddleMIX/pull/311>

2. **问题疑惑与解答**

暂无

### 未来双周计划

1. 第一个pr还有一些问题，解决了：
   - 需要一些常见的这种参数。
   - 有个可以跑通推理的paddle和fd及ppdiffusers环境，可以继续这部分开发了
   - inpaint的界面，可能需要自动涂抹mask的工具，无需手动上传
2. 完成音乐任务的gradio界面
