### PR TITLE
[WeeklyReport] wufei2 2024.05.07~2024.05.19

### DIFF
--- a/Reports/season 2/wufei2/[WeeklyReport]2024.05.07~2024.05.19.md
+++ b/Reports/season 2/wufei2/[WeeklyReport]2024.05.07~2024.05.19.md
@@ -1,0 +1,24 @@
+ ### 姓名
+
+吴斐(wufei2)
+
+### 开发中的快乐开源任务
+
+为PaddleScience案例添加export和inference功能
+
+### 本双周工作
+
+1. **任务 1**
+
+   - 完成了多个为PaddleScience案例添加export和inference功能PR的合入
+
+2. **问题疑惑与解答**
+
+   - 问题 无
+
+     答：
+
+
+### 未来双周计划
+
+1. 认领和完成其他为PaddleScience案例添加export和inference功能的任务


### PR DESCRIPTION
### 姓名

吴斐 (wufei2)

### 本双周工作

1. 完成了多个为PaddleScience案例添加export和inference功能PR的合入
 
### 未来双周计划

1. 认领和完成其他为PaddleScience案例添加export和inference功能的任务

### 详细周报链接：

https://github.com/PFCCLab/Starter/pulls/226