### PR TITLE
[WeeklyReport] LanCole 2025.03.25~2025.04.04

### DIFF
--- a/Reports/season 4/BaolanChen/[WeeklyReport]2024.12.14~2024.12.27.md
+++ b/Reports/season 4/BaolanChen/[WeeklyReport]2024.12.14~2024.12.27.md
@@ -15,4 +15,8 @@ PaddleMIX：飞桨多模态大模型快乐开源活动Jina-CLIP-V2推理
 
 ### 未来双周计划
 
+<<<<<<< HEAD
 1. 模型复现任务：完成Jina-CLIP-V2推理的任务，PR Merge
+=======
+1. 模型复现任务：继续进行Jina-CLIP-V2推理的任务，争取提交PR Merge
+>>>>>>> 4333930 (BaolanChen add 2024.12.14~2024.12.27)

--- a/Reports/season 4/BaolanChen/[WeeklyReport]2024.12.14~2024.12.27.md
+++ b/Reports/season 4/BaolanChen/[WeeklyReport]2024.12.14~2024.12.27.md
@@ -15,4 +15,4 @@ PaddleMIX：飞桨多模态大模型快乐开源活动Jina-CLIP-V2推理
 
 ### 未来双周计划
 
-1. 模型复现任务：继续进行Jina-CLIP-V2推理的任务，争取提交PR Merge
+1. 模型复现任务：完成Jina-CLIP-V2推理的任务，PR Merge

--- a/Reports/season 4/BaolanChen/[WeeklyReport]2024.12.14~2024.12.27.md
+++ b/Reports/season 4/BaolanChen/[WeeklyReport]2024.12.14~2024.12.27.md
@@ -15,8 +15,4 @@ PaddleMIX：飞桨多模态大模型快乐开源活动Jina-CLIP-V2推理
 
 ### 未来双周计划
 
-<<<<<<< HEAD
-1. 模型复现任务：完成Jina-CLIP-V2推理的任务，PR Merge
-=======
 1. 模型复现任务：继续进行Jina-CLIP-V2推理的任务，争取提交PR Merge
->>>>>>> 4333930 (BaolanChen add 2024.12.14~2024.12.27)

--- a/Reports/season 5/LanCole/[WeeklyReport]2025.03.25~2025.04.04.md
+++ b/Reports/season 5/LanCole/[WeeklyReport]2025.03.25~2025.04.04.md
@@ -1,0 +1,19 @@
+### 姓名
+
+陈宝岚(LanCole), 原BaolanChen
+
+### 本双周工作
+
+1. **热身打卡任务**
+   - 完成 Paddle 本地编译
+   - 完成 Stable-Difussion 训练推理打卡任务
+   - [Docathon] 补充缺失的中文 API 文档（Inplace 类）[# 7113](https://github.com/PaddlePaddle/docs/pull/7113)
+
+2. **任务 - PaddleMIX 快乐开源活动**
+   - 报名了Jina-CLIP-V2模型任务，并初步实现模型迁移
+
+
+### 未来双周计划
+
+1. 学习 PaddleMIX 中相关模型迁移案例，提交Jina-CLIP-V2模型迁移代码PR
+2. 进一步了解 Paddle框架开发


### PR DESCRIPTION
### 姓名

LanCole, 原BaolanChen

### 本双周工作

1. **热身打卡任务**
   - 完成 Paddle 本地编译
   - 完成 Stable-Difussion 训练推理打卡任务
   - [Docathon] 补充缺失的中文 API 文档（Inplace 类）[# 7113](https://github.com/PaddlePaddle/docs/pull/7113)

2. **任务 - PaddleMIX 快乐开源活动**
   - 报名了Jina-CLIP-V2模型任务，并初步实现模型迁移


### 未来双周计划

1. 学习 PaddleMIX 中相关模型迁移案例，提交Jina-CLIP-V2模型迁移代码PR
2. 进一步了解 Paddle框架开发
