### PR TITLE
[WeeklyReport] ClaireJunc 2026.02.09~2026.02.22

### DIFF
--- a/Reports/campus/xjtu_xdu/ClaireJunc/[WeeklyReport] 2026.02.09~2026.02.22.md
+++ b/Reports/campus/xjtu_xdu/ClaireJunc/[WeeklyReport] 2026.02.09~2026.02.22.md
@@ -1,0 +1,22 @@
+### 姓名
+
+ClaireJunc
+
+### 本双周工作
+
+1. **文档示例代码修复（热身任务 a）**
+   - 认领并完成了 PaddlePaddle 文档链接修复任务 No.21（[issue #7735](https://github.com/PaddlePaddle/docs/issues/7735)）
+   - 修复文件：`docs/design/mkldnn/int8/README.md`，将失效的 INT8 MKL-DNN post-training quantization 链接替换为正确的相对路径 `./PTQ/README.md`
+   - 已提交 PR：[Doc Link Fix No.21](https://github.com/PaddlePaddle/docs/pull/7747)
+
+2. **完成 Paddle 本地编译（热身任务 b）**
+   - 在本地环境完成 PaddlePaddle 源码编译
+   - 已发送邮件确认
+
+3. **完成 FastDeploy 本地编译（热身任务 c）**
+   - 在本地环境完成 FastDeploy 源码编译
+   - 已发送邮件确认
+
+### 未来双周计划
+
+1. 学习 PaddlePaddle 框架，尝试参与更多开源贡献任务


### PR DESCRIPTION
## 周报提交

提交第一次双周报（2026.02.09~2026.02.22）。

### 本双周工作

1. **文档示例代码修复（热身任务 a）**：完成 PaddlePaddle 文档链接修复任务 No.21，已提交 PR [#7747](https://github.com/PaddlePaddle/docs/pull/7747)
2. **完成 Paddle 本地编译（热身任务 b）**：已完成并发送邮件确认
3. **完成 FastDeploy 本地编译（热身任务 c）**：已完成并发送邮件确认

Related issue: PFCCLab/Starter#812

Made with [Cursor](https://cursor.com)