### PR TITLE
[WeeklyReport] 2560925365-ux 2026.02.09~2026.02.22

### DIFF
--- a/Reports/horse year/2560925365-ux/[WeeklyReport]2026.02.09~2026.02.22.md
+++ b/Reports/horse year/2560925365-ux/[WeeklyReport]2026.02.09~2026.02.22.md
@@ -1,0 +1,42 @@
+### 姓名
+
+唐瑾薇
+
+### 开发中的快乐开源任务
+
+- [PaddlePaddle 文档链接修复](https://github.com/PaddlePaddle/docs/issues/7735)
+
+### 本双周工作
+
+1. **PaddlePaddle 文档链接修复**
+
+   - **Task #79**: 修复 `torch.Tensor.ge_` 文档链接
+     - 将旧格式 `https://docs.pytorch.org/docs/stable/...` 更新为新格式 `https://pytorch.org/docs/stable/...`
+
+   - **Task #86**: 修复 `torch.autograd.function.FunctionCtx.set_materialize_grads` 文档链接
+
+   - **Task #87**: 修复 `torch.autograd.grad_mode.set_grad_enabled` 文档链接
+
+   - **Task #88**: 修复 `torch.autograd.graph.saved_tensors_hooks` 文档链接
+
+   - **Task #85**: `torch.autograd.function.FunctionCtx.saved_tensors` (已使用新格式，无需修改)
+
+   - PR: https://github.com/2560925365-ux/docs/pull/1
+
+2. **飞桨启航计划热身任务**
+
+   - 完成第三个热身任务：文档链接修复实践
+   - 已通过邮件提交热身任务完成证明
+
+3. **问题与挑战**
+
+   - 热身任务多次尝试遇见各种兼容性问题
+   - 需要进一步排查和解决环境配置问题
+
+### 未来双周计划
+
+1. 继续解决热身任务的兼容性问题
+2. 完成剩余的热身任务
+3. 继续参与 PaddlePaddle 快乐开源文档修复任务
+
+非常感谢 @luotao1, @Echo-Nie 老师的指导！


### PR DESCRIPTION
## 双周周报 - 唐瑾薇

### 周报摘要

- **开发中的任务**: PaddlePaddle 文档链接修复 (#7735)
- **本双周完成**: 修复了 4 个 PyTorch 文档链接（#79、#86-88），完成了第三个热身任务
- **下双周计划**: 继续解决热身任务兼容性问题，完成剩余热身任务

### 详细周报

请查看文件内容了解详细工作记录。

### 关联 PR

- PaddlePaddle 文档修复 PR: https://github.com/2560925365-ux/docs/pull/1