### PR TITLE
[WeeklyReport] HZ1ovo 2026.02.09~2026.02.22

### DIFF
--- a/Reports/horse year/HZ1ovo/[WeeklyReport] 2026.02.09~2026.02.22.md
+++ b/Reports/horse year/HZ1ovo/[WeeklyReport] 2026.02.09~2026.02.22.md
@@ -10,13 +10,14 @@
 - TASK 2、3：NumPy 官方文档链接重定向
 - TASK 4: Conll05st 测试数据集原赛事链接关闭，彻底删去并修改存于docs repo中的描述
 - TASK 5：imbd数据集资源重定向
-(TASK 1,4,5)[https://github.com/PaddlePaddle/docs/pull/7767] ; (TASK 2)[https://github.com/PaddlePaddle/docs/pull/7726] ;(TASK 3)[https://github.com/PaddlePaddle/docs/pull/7754]
+
+[TASK 1,4,5](https://github.com/PaddlePaddle/docs/pull/7767)   ； [TASK 2](https://github.com/PaddlePaddle/docs/pull/7726)    ；  [TASK 3](https://github.com/PaddlePaddle/docs/pull/7754)
 
 2. **任务：Paddle 本地编译**
    
 - PaddlePaddle 源码编译(待提交邮件)
 
-3.**额外收获**
+3. **额外收获**
 
 - 学习并完成issue撰写
 - 学习熟悉review流程，验证PR合规与否


### PR DESCRIPTION
## 周报提交

第一次双周报：2026.02.09~2026.02.22

### 姓名

韩芷依

### 本双周工作

1. 任务：文档修复任务 * 5

- TASK 1：Paddle应用实践档案链接重定向 
- TASK 2、3：NumPy 官方文档链接重定向
- TASK 4: Conll05st 测试数据集原赛事链接关闭，彻底删去并修改存于docs repo中的描述
- TASK 5：imbd数据集资源重定向
[TASK 1,4,5](https://github.com/PaddlePaddle/docs/pull/7767)   ； [TASK 2](https://github.com/PaddlePaddle/docs/pull/7726)    ；  [TASK 3](https://github.com/PaddlePaddle/docs/pull/7754)

2. **任务：Paddle 本地编译**
   
- PaddlePaddle 源码编译

3.**额外收获**

- 学习并完成issue撰写
- 学习熟悉review流程，验证PR合规与否

@Echo-Nie 